### PR TITLE
Fixed default port bug with defaults that evaluate to False

### DIFF
--- a/plum/port.py
+++ b/plum/port.py
@@ -6,6 +6,8 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 
+_NULL = ()
+
 
 class ValueSpec(object):
     """
@@ -80,7 +82,7 @@ class ValueSpec(object):
 
 
 class Attribute(ValueSpec):
-    def __init__(self, name, valid_type=None, help=None, default=None, required=False):
+    def __init__(self, name, valid_type=None, help=None, default=_NULL, required=False):
         super(Attribute, self).__init__(name, valid_type=valid_type,
                                         help=help, required=required)
         self._default = default
@@ -107,12 +109,12 @@ class InputPort(Port):
         as required. Otherwise the input should always be marked explicitly
         to be not required even if a default is specified.
         """
-        if default is None:
+        if default is _NULL:
             return required
         else:
             return False
 
-    def __init__(self, name, valid_type=None, help=None, default=None,
+    def __init__(self, name, valid_type=None, help=None, default=_NULL,
                  required=True, validator=None):
         super(InputPort, self).__init__(
             name, valid_type=valid_type, help=help, required=InputPort.required_override(required, default),
@@ -122,7 +124,7 @@ class InputPort(Port):
             _LOGGER.info("the required attribute for the input port '{}' was overridden "
                          "because a default was specified".format(name))
 
-        if default is not None:
+        if default is not _NULL:
             default_valid, msg = self.validate(default)
             if not default_valid:
                 raise ValueError("Invalid default value: {}".format(msg))
@@ -148,12 +150,12 @@ class InputGroupPort(InputPort):
     the whole input itself.
     """
 
-    def __init__(self, name, valid_type=None, help=None, default=None,
+    def __init__(self, name, valid_type=None, help=None, default=_NULL,
                  required=False):
         # We have to set _valid_inner_type before calling the super constructor
         # because it will call validate on the default value (if supplied)
         # which in turn needs this value to be set.
-        if default is not None and not isinstance(default, collections.Mapping):
+        if default is not _NULL and not isinstance(default, collections.Mapping):
             raise ValueError("Input group default must be of type Mapping")
         self._valid_inner_type = valid_type
 

--- a/plum/process.py
+++ b/plum/process.py
@@ -14,6 +14,7 @@ import plum.stack as _stack
 from plum.process_listener import ProcessListener
 from plum.process_spec import ProcessSpec
 from plum.utils import protected
+from plum.port import _NULL
 from . import utils
 
 __all__ = ['Process', 'ProcessState']
@@ -581,7 +582,7 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
         # inputs
         for name, port in self.spec().inputs.iteritems():
             if name not in ins:
-                if port.default:
+                if port.default != _NULL:
                     ins[name] = port.default
                 elif port.required:
                     raise ValueError(

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -115,7 +115,7 @@ class TestProcess(TestCase):
             @classmethod
             def define(cls, spec):
                 super(Proc, cls).define(spec)
-                spec.input("input", default=5, required=False)
+                spec.input('input', default=5, required=False)
 
         # Supply a value
         p = self.loop.create(Proc, inputs={'input': 2})
@@ -124,6 +124,19 @@ class TestProcess(TestCase):
         # Don't supply, use default
         p = self.loop.create(Proc)
         self.assertEqual(p.inputs['input'], 5)
+
+    def test_inputs_default_that_evaluate_to_false(self):
+        for def_val in (True, False, 0, 1):
+            class Proc(DummyProcess):
+                @classmethod
+                def define(cls, spec):
+                    super(Proc, cls).define(spec)
+                    spec.input('input', default=def_val)
+
+            # Don't supply, use default
+            p = self.loop.create(Proc)
+            self.assertIn('input', p.inputs)
+            self.assertEqual(p.inputs['input'], def_val)
 
     def test_run(self):
         p = self.loop.create(DummyProcessWithOutput)


### PR DESCRIPTION
To determine whether a default was specified for a Port the check

	if port.default

was used, which would erroneously miss the cases where a default
was set with a default value that evaluated to False. To solve
this the initial value of a Port's default value is set to the
new variable _NULL which equals an empty tuple. Checking for this
value will tell whether a user specified a default value