### PR TITLE
Simplify code of ClassLoader, load_class

### DIFF
--- a/plum/class_loader.py
+++ b/plum/class_loader.py
@@ -8,7 +8,8 @@ class ClassLoader(object):
     def __init__(self, parent=None):
         self._parent = parent
 
-    def find_class(self, name):
+    @staticmethod
+    def find_class(name):
         """
         Load a class from a string
         """

--- a/plum/utils.py
+++ b/plum/utils.py
@@ -134,10 +134,7 @@ def load_class(classstring):
     """
     Load a class from a string
     """
-    class_data = classstring.split(".")
-    module_path = ".".join(class_data[:-1])
-    class_name = class_data[-1]
-
+    module_path, class_name = classstring.rsplit('.', 1)
     module = importlib.import_module(module_path)
 
     # Finally, retrieve the class


### PR DESCRIPTION
* Make ``ClassLoader.find_class`` a ``staticmethod`` since it doesn't use ``self``.
* Use ``rsplit`` and tuple unpacking to get ``module_path`` and ``class_name``