### PR TITLE
Add partial Python 3 support

### DIFF
--- a/plum/persistence/pickle_persistence.py
+++ b/plum/persistence/pickle_persistence.py
@@ -327,7 +327,7 @@ class PicklePersistence(apricotpy.LoopObject):
         )
 
     def reset_persisted(self, delete=False):
-        for saver in self._savers.itervalues():
+        for saver in self._savers.values():
             saver.stop(delete=delete)
 
         self._savers.clear()

--- a/plum/persistence/pickle_persistence.py
+++ b/plum/persistence/pickle_persistence.py
@@ -8,6 +8,9 @@ import shutil
 import tempfile
 import traceback
 import pickle
+
+from future.utils import raise_from
+
 from plum.process import Process
 from plum.persistence._base import LOGGER
 
@@ -63,7 +66,7 @@ def _ensure_directory(dir_path):
 def _create_saved_instance_state(process):
     """
     Create a saved instance state bundle for a process.
-    
+
     :param process: The process
     :type process: :class:`plum.Process`
     :return: The saved state bundle
@@ -112,8 +115,14 @@ class Saver(object):
             self._lock = RLock(save_file, 'w+b', timeout=0)
             self._lock.acquire()
         except portalocker.LockException as e:
-            e.message = "Unable to lock pickle '{}' someone else must have locked it.\n" + e.message
-            raise e
+            raise_from(
+                portalocker.LockException(
+                    "Unable to lock pickle '{}' someone else must have locked it.\n".format(
+                        save_file
+                    ) + str(e)
+                ),
+                e
+            )
 
         self._save_file = save_file
         self._loop = loop
@@ -165,8 +174,8 @@ class Saver(object):
             _save_locked(process, self._lock)
         except BaseException as e:
             LOGGER.debug(
-                "Failed trying to save pickle for process '{}': "
-                    .format(process.uuid, e.message)
+                "Failed trying to save pickle for process '{}': {}"
+                    .format(process.uuid, str(e))
             )
 
 
@@ -275,7 +284,7 @@ class PicklePersistence(apricotpy.LoopObject):
         return checkpoints
 
     def start_persisting(self):
-        """      
+        """
         Any new processes inserted into the event loop will be persisted at each state transition.
         """
         if self._persisting:

--- a/plum/port.py
+++ b/plum/port.py
@@ -4,17 +4,18 @@ from abc import ABCMeta
 import collections
 import logging
 
+from future.utils import with_metaclass
+
 _LOGGER = logging.getLogger(__name__)
 
 _NULL = ()
 
 
-class ValueSpec(object):
+class ValueSpec(with_metaclass(ABCMeta, object)):
     """
     Specifications relating to a general input/output value including
     properties like whether it is required, valid types, the help string, etc.
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, name, valid_type=None, help=None, required=True,
                  validator=None):
@@ -92,8 +93,7 @@ class Attribute(ValueSpec):
         return self._default
 
 
-class Port(ValueSpec):
-    __metaclass__ = ABCMeta
+class Port(with_metaclass(ABCMeta, ValueSpec)):
     pass
 
 
@@ -174,7 +174,7 @@ class InputGroupPort(InputPort):
 
         if value is not None and self._valid_inner_type is not None:
             # Check that all the members of the dictionary are of the right type
-            for k, v in value.iteritems():
+            for k, v in value.items():
                 if not isinstance(v, self._valid_inner_type):
                     return False, "Group port value {} is not of the right type. Should be of type {}, but is {}.".format(
                         k, self._valid_inner_type, type(v))

--- a/plum/process.py
+++ b/plum/process.py
@@ -10,6 +10,8 @@ import logging
 import time
 import sys
 
+from future.utils import with_metaclass
+
 import plum.stack as _stack
 from plum.process_listener import ProcessListener
 from plum.process_spec import ProcessSpec
@@ -57,7 +59,7 @@ class BundleKeys(Enum):
     CALLBACK_ARGS = 'CALLBACK_ARGS'
 
 
-class Process(apricotpy.persistable.AwaitableLoopObject):
+class Process(with_metaclass(ABCMeta, apricotpy.persistable.AwaitableLoopObject)):
     """
     The Process class is the base for any unit of work in plum.
 
@@ -96,7 +98,6 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
     always called immediately after that state is entered but before being
     executed.
     """
-    __metaclass__ = ABCMeta
 
     # Static class stuff ######################
     _spec_type = ProcessSpec
@@ -511,7 +512,7 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
     def on_fail(self, exc_info):
         """
         Called if the process raised an exception.
-        
+
         :param exc_info: The exception information as returned by sys.exc_info()
         """
         self._fire_event(ProcessListener.on_process_fail)
@@ -583,7 +584,7 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
             ins = dict(inputs)
         # Go through the spec filling in any default and checking for required
         # inputs
-        for name, port in self.spec().inputs.iteritems():
+        for name, port in self.spec().inputs.items():
             if name not in ins:
                 if port.default != _NULL:
                     ins[name] = port.default
@@ -596,10 +597,10 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
 
     @protected
     def encode_input_args(self, inputs):
-        """ 
-        Encode input arguments such that they may be saved in a 
+        """
+        Encode input arguments such that they may be saved in a
         :class:`apricotpy.persistable.Bundle`
-        
+
         :param inputs: A mapping of the inputs as passed to the process
         :return: The encoded inputs
         """
@@ -608,10 +609,10 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
     @protected
     def decode_input_args(self, encoded):
         """
-        Decode saved input arguments as they came from the saved instance state 
+        Decode saved input arguments as they came from the saved instance state
         :class:`apricotpy.persistable.Bundle`
-        
-        :param encoded: 
+
+        :param encoded:
         :return: The decoded input args
         """
         return encoded
@@ -665,7 +666,7 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
 
     def _check_outputs(self):
         # Check that the necessary outputs have been emitted
-        for name, port in self.spec().outputs.iteritems():
+        for name, port in self.spec().outputs.items():
             valid, msg = port.validate(self._outputs.get(name, None))
             if not valid:
                 raise RuntimeError(
@@ -817,7 +818,7 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
 class ListenContext(object):
     """
     A context manager for listening to the Process.
-    
+
     A typical usage would be:
     with ListenContext(producer, listener):
         # Producer generates messages that the listener gets

--- a/plum/process_listener.py
+++ b/plum/process_listener.py
@@ -1,8 +1,8 @@
 from abc import ABCMeta
 
+from future.utils import with_metaclass
 
-class ProcessListener(object):
-    __metaclass__ = ABCMeta
+class ProcessListener(with_metaclass(ABCMeta, object)):
 
     def on_process_start(self, process):
         """

--- a/plum/process_spec.py
+++ b/plum/process_spec.py
@@ -52,13 +52,13 @@ class ProcessSpec(object):
             desc.append("Inputs")
             desc.append("======")
             desc.extend([p.get_description() for k, p in
-                         sorted(self.inputs.iteritems(), key=lambda x: x[0])])
+                         sorted(self.inputs.items(), key=lambda x: x[0])])
 
         if self.outputs:
             desc.append("Outputs")
             desc.append("=======")
             desc.extend([p.get_description() for k, p in
-                         sorted(self.outputs.iteritems(), key=lambda x: x[0])])
+                         sorted(self.outputs.items(), key=lambda x: x[0])])
 
         return "\n".join(desc)
 
@@ -208,14 +208,14 @@ class ProcessSpec(object):
 
         # Check the inputs meet the requirements
         if not self.has_dynamic_input():
-            unexpected = set(inputs.iterkeys()) - set(self.inputs.iterkeys())
+            unexpected = set(inputs.keys()) - set(self.inputs.keys())
             if unexpected:
                 return False, \
                        "Unexpected inputs found: '{}'.  If you want to allow " \
                        "dynamic inputs add dynamic_input() to the spec " \
                        "definition.".format(unexpected)
 
-        for name, port in self.inputs.iteritems():
+        for name, port in self.inputs.items():
             valid, msg = port.validate(inputs.get(name, None))
             if not valid:
                 return False, msg

--- a/plum/rmq/control.py
+++ b/plum/rmq/control.py
@@ -5,6 +5,8 @@ import pika
 import pika.exceptions
 import uuid
 
+from past.builtins import basestring
+
 from plum.rmq.defaults import Defaults
 from plum.rmq.util import add_host_info
 from plum.utils import override
@@ -184,7 +186,7 @@ class ProcessControlSubscriber(apricotpy.TickingLoopObject):
             else:
                 raise RuntimeError("Unknown intent")
         except ValueError as e:
-            result = e.message
+            result = str(e)
         else:
             # Tell the sender that we've dealt with it
             self._send_response(ch, props.reply_to, props.correlation_id, result)

--- a/plum/rmq/launch.py
+++ b/plum/rmq/launch.py
@@ -10,6 +10,8 @@ import pickle
 import traceback
 import uuid
 
+from future.utils import with_metaclass
+
 from plum import process
 from plum.rmq.defaults import Defaults
 from plum.utils import override
@@ -215,12 +217,10 @@ class ProcessLaunchPublisher(apricotpy.TickingLoopObject):
         assert self.in_loop(), "Object is not in the event loop"
 
 
-class _AwaitDone(persistable.AwaitableLoopObject):
+class _AwaitDone(with_metaclass(abc.ABCMeta, persistable.AwaitableLoopObject)):
     PUBLISHER = 'PUBLISHER'
     CORRELATION_ID = 'CORRELATION_ID'
     CONSUMER_TAG = 'CONSUMER_TAG'
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, publisher, process_bundle):
         super(_AwaitDone, self).__init__()

--- a/plum/utils.py
+++ b/plum/utils.py
@@ -58,7 +58,7 @@ class EventHelper(object):
                 _LOGGER.error(
                     "The listener '{}' produced an exception while receiving "
                     "the message '{}':\n{}: {}".format(
-                        l, event_function.__name__, e.__class__.__name__, e.message)
+                        l, event_function.__name__, e.__class__.__name__, str(e))
                 )
                 if self._raise_exceptions:
                     raise
@@ -200,8 +200,8 @@ def set_if_not_none(mapping, key, value):
     """
     Set the given value in a mapping only if the value is not `None`,
     otherwise the mapping is left untouched
-    
-    :param mapping: The mapping to set the value for 
+
+    :param mapping: The mapping to set the value for
     :param key: The mapping key
     :param value: The mapping value
     """

--- a/plum/workflow.py
+++ b/plum/workflow.py
@@ -9,6 +9,9 @@ value is passed to all of them when the workflow starts.
 
 from abc import ABCMeta
 import threading
+
+from future.utils import with_metaclass
+
 from plum.port import DynamicOutputPort
 from plum.process import Process, ProcessSpec
 from plum.process_listener import ProcessListener
@@ -43,8 +46,7 @@ class ProcessLink(object):
             self.sink_process, self.sink_port)
 
 
-class WorkflowListener(object):
-    __metaclass__ = ABCMeta
+class WorkflowListener(with_metaclass(ABCMeta, object)):
 
     def on_workflow_starting(self, workflow):
         """
@@ -115,8 +117,7 @@ class WorkflowListener(object):
         pass
 
 
-class WorkflowSpec(ProcessSpec):
-    __metaclass__ = ABCMeta
+class WorkflowSpec(with_metaclass(ABCMeta, ProcessSpec)):
 
     def __init__(self):
         super(WorkflowSpec, self).__init__()
@@ -141,14 +142,14 @@ class WorkflowSpec(ProcessSpec):
 
     def exposed_inputs(self, process_name):
         proc = self.get_process(process_name)
-        for name, port in proc.spec().raw_inputs.iteritems():
+        for name, port in proc.spec().raw_inputs.items():
             self.input_port(name, port)
             self.link(":{}".format(name),
                       "{}:{}".format(process_name, name))
 
     def exposed_outputs(self, process_name):
         proc = self.get_process(process_name)
-        for name, port in proc.spec().outputs.iteritems():
+        for name, port in proc.spec().outputs.items():
             self.output_port(name, port)
             self.link("{}:{}".format(process_name, name),
                       ":{}".format(name))
@@ -205,8 +206,7 @@ class WorkflowSpec(ProcessSpec):
         return link
 
 
-class Workflow(Process, ProcessListener):
-    __metaclass__ = ABCMeta
+class Workflow(with_metaclass(ABCMeta, Process, ProcessListener)):
 
     # Static class stuff ######################
     _spec_type = WorkflowSpec
@@ -222,7 +222,7 @@ class Workflow(Process, ProcessListener):
         self._wait_event = None
 
         # Create all our subprocess classes
-        for name, proc_class in self.spec().processes.iteritems():
+        for name, proc_class in self.spec().processes.items():
             proc = proc_class.new()
             proc.add_process_listener(self)
             self._process_instances[name] = proc
@@ -279,7 +279,7 @@ class Workflow(Process, ProcessListener):
 
         self._wait_event = threading.Event()
 
-        for proc in self._process_instances.itervalues():
+        for proc in self._process_instances.values():
             try:
                 inputs = self._generate_inputs_for(proc)
                 self._launch_subprocess(proc, inputs)
@@ -291,13 +291,13 @@ class Workflow(Process, ProcessListener):
         self._wait_event = None
 
     def get_local_name(self, process):
-        for name, proc in self._process_instances.iteritems():
+        for name, proc in self._process_instances.items():
             if process == proc:
                 return name
         raise ValueError("Process not in workflow")
 
     def _initialise_inputs(self, **kwargs):
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             try:
                 # Push the input value to the links
                 link = self.spec().get_link(":{}".format(key))

--- a/test/rmq/test_status.py
+++ b/test/rmq/test_status.py
@@ -107,7 +107,7 @@ class TestStatusProvider(TestCase):
         self.assertSetEqual(set([p.pid for p in procs]), set(procs_dict.keys()))
 
         # Check they are all waiting on the same thing
-        waiting_on = set([entry['waiting_on'] for entry in procs_dict.itervalues()])
+        waiting_on = set([entry['waiting_on'] for entry in procs_dict.values()])
         self.assertSetEqual(waiting_on, {str(procs[0].get_waiting_on())})
 
 

--- a/test/test_attributesFrozendict.py
+++ b/test/test_attributesFrozendict.py
@@ -1,4 +1,4 @@
-from util import TestCase
+from .util import TestCase
 from plum.utils import AttributesFrozendict
 
 

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -1,4 +1,4 @@
-from util import TestCase
+from .util import TestCase
 from plum.event import wait_on_process_event, EventEmitter
 from plum import loop_factory
 from plum.test_utils import DummyProcess, ExceptionProcess

--- a/test/test_inputGroupPort.py
+++ b/test/test_inputGroupPort.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring 
+
 from .util import TestCase
 from plum.port import InputGroupPort
 

--- a/test/test_inputGroupPort.py
+++ b/test/test_inputGroupPort.py
@@ -1,4 +1,4 @@
-from util import TestCase
+from .util import TestCase
 from plum.port import InputGroupPort
 
 

--- a/test/test_lang.py
+++ b/test/test_lang.py
@@ -1,4 +1,4 @@
-from util import TestCase
+from .util import TestCase
 from plum.lang import protected, override
 
 

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -1,4 +1,4 @@
-from util import TestCase
+from .util import TestCase
 
 from plum.port import InputPort
 

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -8,7 +8,7 @@ from plum.test_utils import DummyProcess, ExceptionProcess, DummyProcessWithOutp
 from plum.test_utils import ProcessListenerTester
 from plum.utils import override
 from plum.wait_ons import run_until, WaitOnProcessState
-from util import TestCase
+from .util import TestCase
 
 
 class ForgetToCallParent(Process):

--- a/test/test_processSpec.py
+++ b/test/test_processSpec.py
@@ -1,6 +1,6 @@
 import unittest
 from plum.process import ProcessSpec
-from util import TestCase
+from .util import TestCase
 
 
 class StrSubtype(str):

--- a/test/test_valueSpec.py
+++ b/test/test_valueSpec.py
@@ -1,4 +1,4 @@
-from util import TestCase
+from .util import TestCase
 from plum.port import ValueSpec
 
 

--- a/test/test_wait.py
+++ b/test/test_wait.py
@@ -1,7 +1,7 @@
 import apricotpy
 from plum import loop_factory
 from plum.wait import WaitOn
-from util import TestCase
+from .util import TestCase
 
 
 class _DummyWait(WaitOn):

--- a/test/test_wait_ons.py
+++ b/test/test_wait_ons.py
@@ -2,7 +2,7 @@ from plum import loop_factory
 from plum.process import ProcessState
 from plum.test_utils import WaitForSignalProcess, DummyProcess
 from plum import wait_ons
-from util import TestCase
+from .util import TestCase
 
 
 class TestWaitOnProcessStateEvent(TestCase):

--- a/test/test_waiting_process.py
+++ b/test/test_waiting_process.py
@@ -8,7 +8,7 @@ from plum.test_utils import check_process_against_snapshots
 from plum.utils import override
 from plum.test_utils import ProcessSaver
 from plum.wait_ons import run_until
-from util import TestCase
+from .util import TestCase
 
 
 class TestWaitingProcess(TestCase):


### PR DESCRIPTION
Changes the following things:

* ``__metaclass__`` changed to ``future.utils.with_metaclass``
* ``iteritems`` changed to ``items`` etc.
* Use ``past.builtins.basestring`` instead of ``str`` and ``unicode``.
* Change ``from utils import ..`` to ``from .utils import ...`` in tests.