### PR TITLE
Input serialization

### DIFF
--- a/plum/exceptions.py
+++ b/plum/exceptions.py
@@ -28,3 +28,6 @@ class Interrupted(Exception):
 
 class InvalidStateError(Exception):
     pass
+
+class ValidationError(Exception):
+    pass

--- a/plum/process.py
+++ b/plum/process.py
@@ -179,7 +179,7 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
         self.__init(logger)
 
         # Input/output
-        self._check_inputs(inputs)
+        inputs = self._evaluate_inputs(inputs)
         self._raw_inputs = None if inputs is None else utils.AttributesFrozendict(inputs)
         self._parsed_inputs = utils.AttributesFrozendict(self.create_input_args(self.raw_inputs))
         self._outputs = {}
@@ -671,9 +671,9 @@ class Process(apricotpy.persistable.AwaitableLoopObject):
 
     # endregion
 
-    def _check_inputs(self, inputs):
+    def _evaluate_inputs(self, inputs):
         # Check the inputs meet the requirements
-        self.spec().validate(inputs)
+        return self.spec().evaluate(inputs)
 
     def _check_outputs(self):
         # Check that the necessary outputs have been emitted

--- a/plum/process_spec.py
+++ b/plum/process_spec.py
@@ -2,6 +2,7 @@ from plum.port import InputPort, InputGroupPort, OutputPort, \
     DynamicOutputPort, DynamicInputPort
 from plum._base import LOGGER
 from plum.utils import protected
+from .exceptions import ValidationError
 
 
 class ProcessSpec(object):
@@ -215,14 +216,10 @@ class ProcessSpec(object):
                        "dynamic inputs add dynamic_input() to the spec " \
                        "definition.".format(unexpected)
 
-        for name, port in self.inputs.iteritems():
-            valid, msg = port.validate(inputs.get(name, None))
-            if not valid:
-                return False, msg
+        for name, port in self.inputs.items():
+            port.validate(inputs.get(name, None))
 
         if self._validator is not None:
             valid, msg = self._validator(self, inputs)
             if not valid:
-                return False, msg
-
-        return True, None
+                raise ValidationError(msg)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     # http://blog.miguelgrinberg.com/post/the-package-dependency-blues
     # for a useful dicussion
     install_requires=[
-        'apricotpy', 'frozendict', 'portalocker'
+        'apricotpy', 'frozendict', 'portalocker', 'future'
     ],
     extras_require={
         'rmq': ['pika'],

--- a/test/test_inputGroupPort.py
+++ b/test/test_inputGroupPort.py
@@ -1,23 +1,24 @@
 from util import TestCase
 from plum.port import InputGroupPort
+from plum.exceptions import ValidationError
 
 
 class TestInputGroupPort(TestCase):
     def test_validate(self):
         p = InputGroupPort("test")
-        self.assertTrue(p.validate({})[0])
+        p.validate({})
 
         p = InputGroupPort("test", required=True)
-        self.assertFalse(p.validate(None)[0])
-        self.assertTrue(p.validate({})[0])
-        self.assertTrue(p.validate({'a': 'value'})[0])
+        self.assertRaises(ValidationError, p.validate, None)
+        p.validate({})
+        p.validate({'a': 'value'})
 
         p = InputGroupPort("test", default={})
-        self.assertTrue(p.validate(None)[0])
-        self.assertTrue(p.validate({})[0])
+        p.validate(None)
+        p.validate({})
 
         p = InputGroupPort("test", valid_type=basestring)
-        self.assertTrue(p.validate({'a': 'value'})[0])
+        p.validate({'a': 'value'})
 
         p = InputGroupPort("test", required=True, valid_type=(basestring, int))
-        self.assertTrue(p.validate({'a': 'value', 'b': 3}))
+        p.validate({'a': 'value', 'b': 3})

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -1,6 +1,7 @@
 from util import TestCase
 
 from plum.port import InputPort
+from plum.exceptions import ValidationError
 
 
 class TestProcessSpec(TestCase):
@@ -8,5 +9,5 @@ class TestProcessSpec(TestCase):
         ip = InputPort('test', default=5)
         self.assertEqual(ip.default, 5)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             InputPort('test', default=4, valid_type=str)

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -4,10 +4,15 @@ from plum.port import InputPort
 from plum.exceptions import ValidationError
 
 
-class TestProcessSpec(TestCase):
+class TestInputPort(TestCase):
     def test_default(self):
         ip = InputPort('test', default=5)
         self.assertEqual(ip.default, 5)
 
         with self.assertRaises(ValidationError):
             InputPort('test', default=4, valid_type=str)
+
+    def test_serialize(self):
+        ip = InputPort('test', valid_type=int, serialize_fct=int)
+        self.assertEqual(ip.evaluate('5'), 5)
+        self.assertEqual(ip.evaluate(3), 3)

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -201,7 +201,7 @@ class TestProcess(TestCase):
         proc = ~self.loop.create_inserted(DummyProcessWithOutput)
         b = apricotpy.persistable.Bundle(proc)
 
-        self.assertIsNone(b.get(plum.process.BundleKeys.INPUTS, None))
+        self.assertEqual(b.get(plum.process.BundleKeys.INPUTS, {}), {})
         self.assertEqual(len(b[plum.process.BundleKeys.OUTPUTS]), 0)
 
     def test_instance_state(self):

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -8,6 +8,7 @@ from plum.test_utils import DummyProcess, ExceptionProcess, DummyProcessWithOutp
 from plum.test_utils import ProcessListenerTester
 from plum.utils import override
 from plum.wait_ons import run_until, WaitOnProcessState
+from plum.exceptions import ValidationError
 from util import TestCase
 
 
@@ -88,7 +89,7 @@ class TestProcess(TestCase):
             def _run(self, **kwargs):
                 pass
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             self.loop.run_until_complete(self.loop.create(NoDynamic, {'a': 5}))
 
         self.loop.run_until_complete(self.loop.create(WithDynamic, {'a': 5}))

--- a/test/test_processSpec.py
+++ b/test/test_processSpec.py
@@ -1,5 +1,6 @@
 import unittest
 from plum.process import ProcessSpec
+from plum.exceptions import ValidationError
 from util import TestCase
 
 
@@ -14,9 +15,9 @@ class TestProcessSpec(TestCase):
     def test_dynamic_output(self):
         self.spec.dynamic_output(valid_type=str)
         port = self.spec.get_dynamic_output()
-        self.assertTrue(port.validate("foo")[0])
-        self.assertTrue(port.validate(StrSubtype("bar"))[0])
-        self.assertFalse(port.validate(5)[0])
+        port.validate("foo")
+        port.validate(StrSubtype("bar"))
+        self.assertRaises(ValidationError, port.validate, 5)
 
         # Remove dynamic output
         self.spec.no_dynamic_output()
@@ -29,9 +30,9 @@ class TestProcessSpec(TestCase):
         # Now add and check behaviour
         self.spec.dynamic_output(valid_type=str)
         port = self.spec.get_dynamic_output()
-        self.assertTrue(port.validate("foo")[0])
-        self.assertTrue(port.validate(StrSubtype("bar"))[0])
-        self.assertFalse(port.validate(5)[0])
+        port.validate("foo")
+        port.validate(StrSubtype("bar"))
+        self.assertRaises(ValidationError, port.validate, 5)
 
     def test_get_description(self):
         spec = ProcessSpec()
@@ -63,14 +64,7 @@ class TestProcessSpec(TestCase):
         self.spec.input("b", required=False)
         self.spec.validator(is_valid)
 
-        valid, msg = self.spec.validate(inputs={})
-        self.assertFalse(valid, msg)
-
-        valid, msg = self.spec.validate(inputs={'a': 'a', 'b': 'b'})
-        self.assertFalse(valid, msg)
-
-        valid, msg = self.spec.validate(inputs={'a': 'a'})
-        self.assertTrue(valid, msg)
-
-        valid, msg = self.spec.validate(inputs={'b': 'b'})
-        self.assertTrue(valid, msg)
+        self.assertRaises(ValidationError, self.spec.validate, inputs={})
+        self.assertRaises(ValidationError, self.spec.validate, inputs={'a': 'a', 'b': 'b'})
+        self.spec.validate(inputs={'a': 'a'})
+        self.spec.validate(inputs={'b': 'b'})

--- a/test/test_processSpec.py
+++ b/test/test_processSpec.py
@@ -50,7 +50,7 @@ class TestProcessSpec(TestCase):
         desc = spec.get_description()
         self.assertNotEqual(desc, "")
 
-    def test_validate(self):
+    def test_evaluate(self):
         """
         Test the global spec validator functionality.
         """
@@ -64,7 +64,11 @@ class TestProcessSpec(TestCase):
         self.spec.input("b", required=False)
         self.spec.validator(is_valid)
 
-        self.assertRaises(ValidationError, self.spec.validate, inputs={})
-        self.assertRaises(ValidationError, self.spec.validate, inputs={'a': 'a', 'b': 'b'})
-        self.spec.validate(inputs={'a': 'a'})
-        self.spec.validate(inputs={'b': 'b'})
+        self.assertRaises(ValidationError, self.spec.evaluate, inputs={})
+        self.assertRaises(ValidationError, self.spec.evaluate, inputs={'a': 'a', 'b': 'b'})
+        self.spec.evaluate(inputs={'a': 'a'})
+        self.spec.evaluate(inputs={'b': 'b'})
+
+    def test_serialize(self):
+        self.spec.input("a", valid_type=int, serialize_fct=int)
+        self.assertEqual(self.spec.evaluate(inputs={'a': '1'}), {'a': 1})

--- a/test/test_valueSpec.py
+++ b/test/test_valueSpec.py
@@ -1,23 +1,23 @@
 from util import TestCase
 from plum.port import ValueSpec
-
+from plum.exceptions import ValidationError
 
 class TestValueSpec(TestCase):
     def test_required(self):
         s = ValueSpec("required_value", required=True)
 
-        self.assertFalse(s.validate(None)[0])
-        self.assertTrue(s.validate(5)[0])
+        self.assertRaises(ValidationError, s.validate, None)
+        s.validate(5)
 
     def test_validate(self):
         s = ValueSpec("required_value", valid_type=int)
 
-        self.assertTrue(s.validate(5)[0])
-        self.assertFalse(s.validate('a')[0])
+        self.assertRaises(ValidationError, s.validate, 'a')
+        s.validate(5)
 
     def test_validator(self):
         s = ValueSpec("valid_with_validator",
                       validator=lambda x: isinstance(x, int))
 
-        self.assertTrue(s.validate(5)[0])
-        self.assertFalse(s.validate('s')[0])
+        self.assertRaises(ValidationError, s.validate, 's')
+        s.validate(5)


### PR DESCRIPTION
Adds a ``serialize_fct`` keyword argument to ``InputPort``. The serialization function is invoked if the current type of the input does not match ``valid_type``.

A few things need explaining:
* The ``validate`` method of ``InputSpec`` is replaced with ``evaluate``, which does serialization + validation
* Because the ``evaluate`` method needs to return the modified inputs, ``Port.validate`` is changed to use exceptions instead of return values -- otherwise it becomes a mess of too many return values. The ``ValidationError`` class is introduced for this. Exceptions are chained with ``future.utils.raise_from`` (e.g., to add information about which process the exception came from).

Open questions:
- [ ] When ``valid_type=None``, should the serialization always be invoked, or never?
- [ ] Is it ok to remove the ``validate`` function from ``InputSpec``, or is it used also outside of ``Process``?