### PR TITLE
Support for fast-forwarding in 0.7.x

### DIFF
--- a/plum/engine/parallel.py
+++ b/plum/engine/parallel.py
@@ -59,7 +59,7 @@ class MultithreadedEngine(execution_engine.ExecutionEngine, ProcessMonitorListen
 
     @override
     def run(self, process):
-        f = self._executor.submit(Process.run_until_complete, process)
+        f = self._executor.submit(type(process).run_until_complete, process)
         self._processes[process.pid] = f
         return self.Future(process, f)
 

--- a/plum/engine/serial.py
+++ b/plum/engine/serial.py
@@ -127,7 +127,7 @@ class SerialEngine(ExecutionEngine):
         if not isinstance(process, Process):
             raise TypeError("process must be of type Process")
 
-        return SerialEngine.Future(Process.run_until_complete, process)
+        return SerialEngine.Future(type(process).run_until_complete, process)
 
     def run_and_block(self, process_class, inputs):
         """
@@ -154,6 +154,3 @@ class SerialEngine(ExecutionEngine):
 
     def stop(self, pid):
         pass
-
-
-

--- a/plum/process.py
+++ b/plum/process.py
@@ -361,9 +361,12 @@ class Process(object):
         assert self._called, \
             "on_create was not called\n" \
             "Hint: Did you forget to call the superclass method?"
-        MONITOR.process_created(self)
 
-        self._state = ProcessState.CREATED
+        # Enables fast-forwarding in the on_create method, by explicitly setting
+        # the _state
+        if self._state is None:
+            MONITOR.process_created(self)
+            self._state = ProcessState.CREATED
 
     def perform_start(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@
 from setuptools import setup
 
 __license__ = "GPLv3 and MIT, see LICENSE file"
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 __contributors__ = "Martin Uhrin"
 
 setup(
-    name="plum",
+    name="plumpy",
     version=__version__,
     description='A python workflow library',
     long_description=open('README.md').read(),
@@ -21,6 +21,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
+    keywords='workflow multithreaded rabbitmq',
     # Abstract dependencies.  Concrete versions are listed in
     # requirements.txt
     # See https://caremad.io/2013/07/setup-vs-requirement/ for an explanation

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 __license__ = "GPLv3 and MIT, see LICENSE file"
-__version__ = "0.7.10"
+__version__ = "0.7.11"
 __contributors__ = "Martin Uhrin"
 
 setup(


### PR DESCRIPTION
This contains the following changes:

* ``submit`` uses ``type(process)`` instead of hard-coding ``Process`` to get the ``run_until_complete`` method. This allows the AiiDA Process class to override the ``run_until_complete`` behavior.
* Only change the ``_state`` to ``CREATED`` if it is None before. This makes sure that the system doesn't try to re-run cached processes.

Bumps the version number to ``0.7.11``.