### PR TITLE
Inherit ClassNotFoundException from ImportError

### DIFF
--- a/plum/exceptions.py
+++ b/plum/exceptions.py
@@ -2,7 +2,7 @@ class CancelledError(Exception):
     pass
 
 
-class ClassNotFoundException(Exception):
+class ClassNotFoundException(ImportError):
     pass
 
 


### PR DESCRIPTION
This makes it easier to catch problems in ``load_class``, because now if the module doesn't exist it raises ``ImportError``, and if the class doesn't exist it raises ``ClassNotFoundException``.

Alternatively, we could also get rid of the custom exception class and raise a plain ``ImportError``.