### PR TITLE
Fix a bug in ProcessSpec._create_port

### DIFF
--- a/plum/process_spec.py
+++ b/plum/process_spec.py
@@ -107,7 +107,7 @@ class ProcessSpec(object):
             raise RuntimeError('Cannot add an output port after the spec has been sealed')
 
         namespace = name.split(self.namespace_separator)
-        port_name = namespace.pop(0)
+        port_name = namespace.pop()
 
         if namespace:
             namespace = self.namespace_separator.join(namespace)

--- a/test/test_process_spec.py
+++ b/test/test_process_spec.py
@@ -1,4 +1,5 @@
 import unittest
+from plum.port import PortNamespace, InputPort
 from plum.process import ProcessSpec
 from .utils import TestCase
 
@@ -54,6 +55,22 @@ class TestProcessSpec(TestCase):
         spec.output('test')
         description = spec.get_description()
         self.assertNotEqual(description, {})
+
+    def test_input_namespaced(self):
+        """
+        Test the creation of a namespaced input port
+        """
+        self.spec.input('some.name.space.a', valid_type=int)
+
+        self.assertTrue('some' in self.spec.inputs)
+        self.assertTrue('name' in self.spec.inputs['some'])
+        self.assertTrue('space' in self.spec.inputs['some']['name'])
+        self.assertTrue('a' in self.spec.inputs['some']['name']['space'])
+
+        self.assertTrue(isinstance(self.spec.inputs.get_port('some'), PortNamespace))
+        self.assertTrue(isinstance(self.spec.inputs.get_port('some.name'), PortNamespace))
+        self.assertTrue(isinstance(self.spec.inputs.get_port('some.name.space'), PortNamespace))
+        self.assertTrue(isinstance(self.spec.inputs.get_port('some.name.space.a'), InputPort))
 
     def test_validate(self):
         """


### PR DESCRIPTION
The `_create_port` method of the `ProcessSpec` class contained a bug that
was not covered by the tests. When a name was passed that is namespaced
the port name was determined by popping the first element after splitting
the name on the namespace separator. However, the first element would
be the first level of the namespace and not the port name. The actual
port name is the last element of the split namespaced name. Fixed the
bug and added a test that covers this