### PR TITLE
Have Process.create_input_args recurse into PortNamespaces it encounters

### DIFF
--- a/plum/port.py
+++ b/plum/port.py
@@ -25,7 +25,7 @@ class ValueSpec(with_metaclass(ABCMeta, object)):
         self._validator = validator
 
     def __str__(self):
-        return '; '.join(self.get_description())
+        return json.dumps(self.get_description())
 
     def get_description(self):
         """

--- a/plum/process.py
+++ b/plum/process.py
@@ -451,10 +451,10 @@ class Process(with_metaclass(ABCMeta, base_process.ProcessStateMachine)):
         :return: an AttributesFrozenDict with the inputs, complemented with port default values
         :raises: ValueError if no input was specified for a required port without a default value
         """
-        result = {}
-
         if inputs is None:
             inputs = {}
+        else:
+            inputs = dict(inputs)
 
         # Go through the spec filling in any default and checking for required inputs
         for name, port in port_namespace.items():
@@ -468,11 +468,11 @@ class Process(with_metaclass(ABCMeta, base_process.ProcessStateMachine)):
                 port_value = inputs[name]
 
             if isinstance(port, PortNamespace):
-                result[name] = self.create_input_args(port, port_value)
+                inputs[name] = self.create_input_args(port, port_value)
             else:
-                result[name] = port_value
+                inputs[name] = port_value
 
-        return utils.AttributesFrozendict(result)
+        return utils.AttributesFrozendict(inputs)
 
     def exposed_inputs(self, process_class, namespace=None):
         """

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -443,6 +443,30 @@ class TestProcessNamespace(utils.TestCaseWithLoop):
         self.assertTrue(isinstance(input_value, int))
         self.assertEquals(input_value, 5)
 
+    def test_namespaced_process_inputs(self):
+        """
+        Test the parsed inputs for a process with namespace only contains expected dictionaries
+        """
+        class NameSpacedProcess(Process):
+
+            @classmethod
+            def define(cls, spec):
+                super(NameSpacedProcess, cls).define(spec)
+                spec.input('some.name.space.a', valid_type=int)
+                spec.input('test', valid_type=int, default=6)
+                spec.input('label', valid_type=basestring, required=False)
+                spec.input('description', valid_type=basestring, required=False)
+                spec.input('store_provenance', valid_type=bool, default=True)
+
+        proc = NameSpacedProcess(inputs={'some': {'name': {'space': {'a': 5}}}})
+
+        self.assertEqual(proc.inputs.test, 6)
+        self.assertEqual(proc.inputs.store_provenance, True)
+        self.assertEqual(proc.inputs.some.name.space.a, 5)
+
+        self.assertTrue('label' not in proc.inputs)
+        self.assertTrue('description' not in proc.inputs)
+
     def test_namespaced_process_dynamic(self):
         """
         Test that the input creation for processes with a dynamic nested port namespace is properly handled

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -443,6 +443,33 @@ class TestProcessNamespace(utils.TestCaseWithLoop):
         self.assertTrue(isinstance(input_value, int))
         self.assertEquals(input_value, 5)
 
+    def test_namespaced_process_dynamic(self):
+        """
+        Test that the input creation for processes with a dynamic nested port namespace is properly handled
+        """
+        namespace = 'name.space'
+
+        class DummyDynamicProcess(Process):
+
+            @classmethod
+            def define(cls, spec):
+                super(DummyDynamicProcess, cls).define(spec)
+                spec.input_namespace(namespace)
+                spec.inputs['name']['space'].dynamic = True
+                spec.inputs['name']['space'].valid_type = int
+
+        original_inputs = [1, 2, 3, 4]
+
+        inputs = {'name': {'space': {str(l): l for l in original_inputs}}}
+        p = DummyDynamicProcess(inputs=inputs)
+
+        for label, value in p.inputs['name']['space'].items():
+            self.assertTrue(label in inputs['name']['space'])
+            self.assertEqual(int(label), value)
+            original_inputs.remove(value)
+
+        # Make sure there are no other inputs
+        self.assertFalse(original_inputs)
 
 class TestProcessEvents(utils.TestCaseWithLoop):
     def setUp(self):


### PR DESCRIPTION
Fixes #24 

The inputs dictionary that is passed to `create_input_args` may contain
nested dictionaries to satisfy a potentially input port namespace that
contains nested port namespaces. It is important that when mapping the
input dictionaries to the nested input port namespace, the returned
dictionaries are all turned into `AttributesFrozenDict` instances