### PR TITLE
Fix output validation with namespaces

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -175,7 +175,7 @@ class Process(with_metaclass(ABCMeta, base_process.ProcessStateMachine)):
     @classmethod
     def recreate_from(cls, saved_state, load_context=None):
         """
-        Recreate a process from a saved state, passing any positional and 
+        Recreate a process from a saved state, passing any positional and
         keyword arguments on to load_instance_state
 
         :param saved_state: The saved state to load from
@@ -588,7 +588,8 @@ class Process(with_metaclass(ABCMeta, base_process.ProcessStateMachine)):
 
     def _check_outputs(self):
         # Check that the necessary outputs have been emitted
+        wrapped = utils.wrap_dict(self._outputs, separator=self.spec().namespace_separator)
         for name, port in self.spec().outputs.items():
-            valid, msg = port.validate(self._outputs.get(name, ports.UNSPECIFIED))
+            valid, msg = port.validate(wrapped.get(name, ports.UNSPECIFIED))
             if not valid:
                 raise RuntimeError("Process {} failed because {}".format(self.get_name(), msg))

--- a/plumpy/utils.py
+++ b/plumpy/utils.py
@@ -4,7 +4,7 @@ import importlib
 import inspect
 import logging
 import threading
-from collections import deque
+from collections import deque, defaultdict
 
 import frozendict
 
@@ -277,3 +277,16 @@ def load_module(fullname):
         raise ValueError("Could not load a module corresponding to '{}'".format(fullname))
 
     return mod, remainder
+
+def wrap_dict(flat_dict, separator='.'):
+    sub_dicts = defaultdict(dict)
+    res = {}
+    for key, value in flat_dict.items():
+        if separator in key:
+            namespace, sub_key = key.split(separator, 1)
+            sub_dicts[namespace][sub_key] = value
+        else:
+            res[key] = value
+    for namespace, sub_dict in sub_dicts.items():
+        res[namespace] = wrap_dict(sub_dict)
+    return res

--- a/test/test_workchains.py
+++ b/test/test_workchains.py
@@ -389,6 +389,21 @@ class TestWorkchain(utils.TestCaseWithLoop):
     #     workchain = Wf(runner=runner)
     #     workchain.execute()
 
+    def test_output_namespace(self):
+        """Test running a workchain with nested outputs."""
+        class TestWorkChain(WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(TestWorkChain, cls).define(spec)
+                spec.output('x.y', required=True)
+                spec.outline(cls.run)
+
+            def run(self):
+                self.out('x.y', 5)
+
+        workchain = TestWorkChain()
+        workchain.execute()
+
     def test_exception_tocontext(self):
         my_exception = RuntimeError("Should not be reached")
 

--- a/test/test_workchains.py
+++ b/test/test_workchains.py
@@ -396,9 +396,9 @@ class TestWorkchain(utils.TestCaseWithLoop):
             def define(cls, spec):
                 super(TestWorkChain, cls).define(spec)
                 spec.output('x.y', required=True)
-                spec.outline(cls.run)
+                spec.outline(cls.do_run)
 
-            def run(self):
+            def do_run(self):
                 self.out('x.y', 5)
 
         workchain = TestWorkChain()


### PR DESCRIPTION
Adds a ``wrap_dict`` method, which turns a flat dictionary into a nested one by splitting the keys at the namespace separator. The outputs are passed to the port validation method as a nested dict, as discussed with @sphuber.