### PR TITLE
Make Process YAMLable

### DIFF
--- a/plumpy/base_process.py
+++ b/plumpy/base_process.py
@@ -393,6 +393,11 @@ class Killed(State):
 class ProcessStateMachineMeta(abc.ABCMeta, state_machine.StateMachineMeta):
     pass
 
+# Make ProcessStateMachineMeta instances (classes) YAML - able
+yaml.representer.Representer.add_representer(
+    ProcessStateMachineMeta,
+    yaml.representer.Representer.represent_name
+)
 
 @persistence.auto_persist('_paused_flag')
 class ProcessStateMachine(with_metaclass(ProcessStateMachineMeta,


### PR DESCRIPTION
This adds the "represent_name" YAML representer to ``ProcessStateMachineMeta``, which mean that classes of that type are YAMLed by their name.

The reason for this is to allow ``WorkChain`` classes as ``non_db`` arguments in AiiDA workchains.

See the related issue on PyYAML (about ABCMeta): https://github.com/yaml/pyyaml/issues/36