### PR TITLE
Implement concept of unsuccessful result in FINISHED state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache
 
 # C extensions
 *.so

--- a/plumpy/__init__.py
+++ b/plumpy/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import *
 from .futures import *
 from .persistence import *
 from .ports import *
+from .base_process import *
 from .processes import *
 from .process_comms import *
 from .process_listener import *
@@ -17,7 +18,7 @@ from .utils import *
 from .version import *
 from .workchains import *
 
-__all__ = (events.__all__ + exceptions.__all__ + processes.__all__ +
+__all__ = (events.__all__ + exceptions.__all__ + processes.__all__ + base_process.__all__ +
            utils.__all__ + futures.__all__ + mixins.__all__ + ['stack'] +
            persistence.__all__ + communications.__all__ + process_comms.__all__ +
            version.__all__, process_listener.__all__ + workchains.__all__ + class_loader.__all__ +
@@ -33,4 +34,4 @@ class NullHandler(logging.Handler):
         pass
 
 
-logging.getLogger("plum").addHandler(NullHandler())
+logging.getLogger("plumpy").addHandler(NullHandler())

--- a/plumpy/base_process.py
+++ b/plumpy/base_process.py
@@ -24,8 +24,8 @@ from .persistence import auto_persist
 from . import stack
 from . import utils
 
-__all__ = ['ProcessStateMachine', 'ProcessState',
-           'Created', 'Running', 'Waiting', 'Finished', 'Excepted', 'Killed',
+__all__ = ['ProcessStateMachine', 'ProcessState', 'KilledError', 'UnsuccessfulResult',
+           'Created', 'Running', 'Waiting', 'Finished', 'Excepted', 'Killed', 'InvalidStateError',
            # Commands
            'Kill', 'Stop', 'Wait', 'Continue']
 
@@ -40,6 +40,13 @@ NULL = __NULL()
 
 class KilledError(BaseException):
     """The process was killed."""
+
+
+class UnsuccessfulResult(object):
+    """The result of the process was unsuccessful"""
+
+    def __init__(self, result=None):
+        self.result = result
 
 
 # region Commands
@@ -69,8 +76,9 @@ class Wait(Command):
 
 @auto_persist('result')
 class Stop(Command):
-    def __init__(self, result):
+    def __init__(self, result, successful):
         self.result = result
+        self.successful = successful
 
 
 @auto_persist('args', 'kwargs')
@@ -279,7 +287,11 @@ class Running(State):
                     return
                 else:
                     if not isinstance(result, Command):
-                        result = Stop(result)
+
+                        if isinstance(result, UnsuccessfulResult):
+                            result = Stop(result.result, False)
+                        else:
+                            result = Stop(result, True)
 
                     if self._pausing is not None:
                         self._command = result
@@ -296,7 +308,7 @@ class Running(State):
         elif isinstance(command, Pause):
             self.pause()
         elif isinstance(command, Stop):
-            self.transition_to(ProcessState.FINISHED, command.result)
+            self.transition_to(ProcessState.FINISHED, command.result, command.successful)
         elif isinstance(command, Wait):
             self.transition_to(ProcessState.WAITING, command.continue_fn, command.msg, command.data)
         elif isinstance(command, Continue):
@@ -399,13 +411,14 @@ class Excepted(State):
         return type(self.exception), self.exception, self.traceback
 
 
-@auto_persist('result')
+@auto_persist('result', 'successful')
 class Finished(State):
     LABEL = ProcessState.FINISHED
 
-    def __init__(self, process, result):
+    def __init__(self, process, result, successful):
         super(Finished, self).__init__(process)
         self.result = result
+        self.successful = successful
 
 
 @auto_persist('msg')
@@ -572,7 +585,7 @@ class ProcessStateMachine(with_metaclass(ProcessStateMachineMeta,
         elif state_label == ProcessState.WAITING:
             call_with_super_check(self.on_wait, state.data)
         elif state_label == ProcessState.FINISHED:
-            call_with_super_check(self.on_finish, state.result)
+            call_with_super_check(self.on_finish, state.result, state.successful)
         elif state_label == ProcessState.KILLED:
             call_with_super_check(self.on_kill, state.msg)
         elif state_label == ProcessState.EXCEPTED:
@@ -623,7 +636,7 @@ class ProcessStateMachine(with_metaclass(ProcessStateMachineMeta,
         pass
 
     @super_check
-    def on_finish(self, result):
+    def on_finish(self, result, successful):
         pass
 
     @super_check
@@ -667,6 +680,16 @@ class ProcessStateMachine(with_metaclass(ProcessStateMachineMeta,
             raise self._state.exception
         else:
             raise InvalidStateError
+
+    def successful(self):
+        """
+        Returns whether the result of the process is considered successful
+        Will raise if the process is not in the FINISHED state
+        """
+        try:
+            return self._state.successful
+        except AttributeError:
+            raise InvalidStateError('process is not in the finished state')
 
     # region commands
     @event(to_states=(Running, Waiting, Excepted))

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -6,6 +6,7 @@ import time
 import uuid
 
 from future.utils import with_metaclass
+from kiwipy import CancelledError
 
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -14,6 +15,7 @@ from . import events
 from . import futures
 from . import base
 from . import base_process
+from .base.state_machine import StateEntryFailed
 from .base_process import Continue, Wait, Kill, Stop, ProcessState, Waiting
 from .base import TransitionFailed
 from . import persistence
@@ -65,7 +67,10 @@ class Executor(ProcessListener):
             if process.paused:
                 process.play()
 
-            return loop.run_sync(lambda: self._future)
+            try:
+                return loop.run_sync(lambda: self._future)
+            except CancelledError:
+                return process.result()
         finally:
             self._future = None
             self._loop = None
@@ -365,9 +370,15 @@ class Process(with_metaclass(ABCMeta, base_process.ProcessStateMachine)):
         super(Process, self).on_pause()
         self._fire_event(ProcessListener.on_process_played)
 
-    def on_finish(self, result):
-        super(Process, self).on_finish(result)
-        self._check_outputs()
+    def on_finish(self, result, successful):
+        super(Process, self).on_finish(result, successful)
+
+        if successful:
+            try:
+                self._check_outputs()
+            except ValueError:
+                raise StateEntryFailed(ProcessState.FINISHED, result, False)
+
         self.future().set_result(self.outputs)
         self._fire_event(ProcessListener.on_process_finished, result)
 
@@ -525,4 +536,4 @@ class Process(with_metaclass(ABCMeta, base_process.ProcessStateMachine)):
         for name, port in self.spec().outputs.items():
             valid, msg = port.validate(wrapped.get(name, ports.UNSPECIFIED))
             if not valid:
-                raise RuntimeError("Process {} failed because {}".format(self.get_name(), msg))
+                raise ValueError(msg)

--- a/plumpy/test_utils.py
+++ b/plumpy/test_utils.py
@@ -138,8 +138,8 @@ class EventsTesterMixin(object):
         self.called('resume')
 
     @utils.override
-    def on_finish(self, result):
-        super(EventsTesterMixin, self).on_finish(result)
+    def on_finish(self, result, successful):
+        super(EventsTesterMixin, self).on_finish(result, successful)
         self.called('finish')
 
     @utils.override


### PR DESCRIPTION
A process needs to be able to return a result that indicates
that the result is unsuccessful. This would then indicated that
in the on_finish method, the outputs should not be checked as
the unsuccessful result already indicates that something went
wrong. If the process result did not already indicate unsuccessfulness
the outputs will be checked and if that validation fails, the
result will be marked unsuccessful after all