### PR TITLE
Use yaml.dump to persist the classloader in a bundle.

### DIFF
--- a/plumpy/persistence.py
+++ b/plumpy/persistence.py
@@ -65,7 +65,7 @@ class Bundle(dict):
         else:
             if load_context is None:
                 load_context = LoadContext()
-            load_context.copyextend(class_loader=yaml.load(class_loader_dump))
+            load_context = load_context.copyextend(class_loader=yaml.load(class_loader_dump))
 
         return Savable.load(self, load_context)
 

--- a/plumpy/persistence.py
+++ b/plumpy/persistence.py
@@ -149,7 +149,7 @@ class PicklePersister(Persister):
     in pickles on a filesystem.
     """
 
-    def __init__(self, pickle_directory):
+    def __init__(self, pickle_directory, class_loader_=None):
         """
         Instantiate a PicklePersister object that will persist processes by
         writing their bundles to a pickle in a directory specified by the
@@ -165,6 +165,7 @@ class PicklePersister(Persister):
             raise ValueError('failed to create the pickle directory at {}'.format(pickle_directory))
 
         self._pickle_directory = pickle_directory
+        self._class_loader = class_loader_
 
     @staticmethod
     def ensure_pickle_directory(dirpath):
@@ -220,7 +221,7 @@ class PicklePersister(Persister):
         :param tag: optional checkpoint identifier to allow distinguishing
             multiple checkpoints for the same process
         """
-        bundle = Bundle(process)
+        bundle = Bundle(process, class_loader_=self._class_loader)
         checkpoint = PersistedCheckpoint(process.pid, tag)
         persisted_pickle = PersistedPickle(checkpoint, bundle)
 

--- a/plumpy/persistence.py
+++ b/plumpy/persistence.py
@@ -8,6 +8,8 @@ import os
 import pickle
 from future.utils import with_metaclass
 
+import yaml
+
 from . import class_loader
 from . import futures
 from . import utils
@@ -43,7 +45,7 @@ class Bundle(dict):
 
         # If we have a class loader, save it in the bundle
         if class_loader_ is not None:
-            Savable.set_custom_meta(self, self.CLASS_LOADER, utils.class_name(class_loader_))
+            Savable.set_custom_meta(self, self.CLASS_LOADER, yaml.dump(class_loader_))
 
         self.update(savable.save(class_loader_=class_loader_))
 
@@ -57,13 +59,13 @@ class Bundle(dict):
         :rtype: :class:`Savable`
         """
         try:
-            class_loader_name = Savable.get_custom_meta(self, self.CLASS_LOADER)
+            class_loader_dump = Savable.get_custom_meta(self, self.CLASS_LOADER)
         except ValueError:
             pass
         else:
             if load_context is None:
                 load_context = LoadContext()
-            load_context.copyextend(class_loader=utils.load_object(class_loader_name))
+            load_context.copyextend(class_loader=yaml.load(class_loader_dump))
 
         return Savable.load(self, load_context)
 


### PR DESCRIPTION
Fixes https://github.com/aiidateam/aiida_core/issues/1345 (after updating the requirements).