### PR TITLE
Catch exceptions thrown by load_checkpoint in ProcessLoader._continue

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -258,6 +258,7 @@ class PortNamespace(collections.MutableMapping, Port):
                 'default': self.default,
                 'dynamic': self.dynamic,
                 'valid_type': str(self.valid_type),
+                'help': self.help,
             }
         }
 


### PR DESCRIPTION
Fixes #45 

If the checkpoint of the process that needs to be continued cannot
be loaded, the task should be rejected