### PR TITLE
Keep exposed port memory and overload PortNamespace attributes on absorb

### DIFF
--- a/plumpy/process_spec.py
+++ b/plumpy/process_spec.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import collections
 import json
 import logging
 
@@ -30,6 +31,8 @@ class ProcessSpec(object):
         # Create the input and output port namespace
         self._ports.create_port_namespace(self.NAME_INPUTS_PORT_NAMESPACE)
         self._ports.create_port_namespace(self.NAME_OUTPUTS_PORT_NAMESPACE)
+        self._exposed_inputs = collections.defaultdict(lambda: collections.defaultdict(list))
+        self._exposed_outputs = collections.defaultdict(lambda: collections.defaultdict(list))
 
     def __str__(self):
         return json.dumps(self.get_description(), sort_keys=True, indent=4)
@@ -190,42 +193,78 @@ class ProcessSpec(object):
         """
         return self.outputs.validate(outputs)
 
-    def expose_inputs(self, process_class, namespace=None, exclude=(), include=None):
+    def expose_inputs(self, process_class, namespace=None, exclude=(), include=None, namespace_options={}):
         """
         This method allows one to automatically add the inputs from another Process to this ProcessSpec.
         The optional namespace argument can be used to group the exposed inputs in a separated PortNamespace.
-        Specific input ports from the exposed process can be excluded or included, but they are mutually exclusive
-        and only one can be specified at a time.
+        The exclude and include arguments can be used to restrict the set of ports that are exposed. Note that
+        these two options are mutually exclusive.
 
         :param process_class: the Process class whose inputs to expose
         :param namespace: a namespace in which to place the exposed inputs
-        :param exclude: list or tuple of input keys to exclude from being exposed
-        :param include: list or tuple of input keys to include as exposed inputs
+        :param exclude: list or tuple of input ports that are to be excluded
+        :param include: list or tuple of input ports that are to be included
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
+        """
+        self._expose_ports(
+            process_class=process_class,
+            source=process_class.spec().inputs,
+            destination=self.inputs,
+            expose_memory=self._exposed_inputs,
+            namespace=namespace,
+            exclude=exclude,
+            include=include,
+            namespace_options=namespace_options,
+        )
+
+    def expose_outputs(self, process_class, namespace=None, exclude=(), include=None, namespace_options={}):
+        """
+        This method allows one to automatically add the ouputs from another Process to this ProcessSpec.
+        The optional namespace argument can be used to group the exposed outputs in a separated PortNamespace.
+        The exclude and include arguments can be used to restrict the set of ports that are exposed. Note that
+        these two options are mutually exclusive.
+
+        :param process_class: the Process class whose outputs to expose
+        :param namespace: a namespace in which to place the exposed outputs
+        :param exclude: list or tuple of input ports that are to be excluded
+        :param include: list or tuple of input ports that are to be included
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
+        """
+        self._expose_ports(
+            process_class=process_class,
+            source=process_class.spec().outputs,
+            destination=self.outputs,
+            expose_memory=self._exposed_outputs,
+            namespace=namespace,
+            exclude=exclude,
+            include=include,
+            namespace_options=namespace_options,
+        )
+
+    def _expose_ports(self, process_class, source, destination, expose_memory, namespace, exclude, include,
+                      namespace_options={}):
+        """
+        Expose ports from a source PortNamespace of the ProcessSpec of a Process class into the destination
+        PortNamespace of this ProcessSpec. If the namespace is specified, the ports will be exposed in that sub
+        namespace. The set of ports can be restricted using the mutually exclusive exclude and include tuples.
+        The namespace_options will be used to override the properties of the PortNamespace into which the ports
+        are exposed, whether that has been newly created or existed already.
+
+        :param process_class: the Process class whose outputs to expose
+        :param source: the PortNamespace whose ports are to be exposed
+        :param destination: the PortNamespace into which the ports are to be exposed
+        :param namespace: a namespace in which to place PortNamespace with the exposed outputs
+        :param exclude: list or tuple of input ports that are to be excluded
+        :param include: list or tuple of input ports that are to be included
+        :param namespace_options: a dictionary with mutable PortNamespace property values to override
         """
         if exclude and include is not None:
             raise ValueError('exclude and include are mutually exclusive')
 
-        if namespace is None:
-            port_namespace = self.inputs
+        if namespace:
+            port_namespace = destination.create_port_namespace(namespace)
         else:
-            port_namespace = self.inputs.create_port_namespace(namespace)
+            port_namespace = destination
 
-        port_namespace.absorb(process_class.spec().inputs, exclude, include)
-
-    def exposed_inputs(self, inputs, process_class, namespace=None):
-        """
-        Return a dictionary of inputs that were exposed for a given Process class under an optional namespace.
-        The exposed inputs dictionary will effectively be obtained by projecting the inputs dictionary on the
-        input port namespace of the process class
-
-        :param inputs: the dictionary of validated inputs passed to the Process
-        :param process_class: process class whose inputs to try and retrieve
-        :param namespace: optional sub PortNamespace in which to look for the inputs
-        """
-        if namespace is not None:
-            inputs = inputs[namespace]
-
-        port_namespace = process_class.spec().inputs
-        project_inputs = port_namespace.project(inputs)
-
-        return project_inputs
+        absorbed_ports = port_namespace.absorb(source, exclude, include, namespace_options)
+        expose_memory[namespace][process_class] = absorbed_ports

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -1030,16 +1030,6 @@ class Process(with_metaclass(ProcessStateMachineMeta,
 
         return utils.AttributesFrozendict(result)
 
-    def exposed_inputs(self, process_class, namespace=None):
-        """
-        Gather a dictionary of the inputs that were exposed for a given Process
-        class under an optional namespace.
-
-        :param process_class: Process class whose inputs to try and retrieve
-        :param namespace: PortNamespace in which to look for the inputs
-        """
-        return self.spec().exposed_inputs(self.inputs, process_class, namespace)
-
     @protected
     def encode_input_args(self, inputs):
         """

--- a/plumpy/utils.py
+++ b/plumpy/utils.py
@@ -243,3 +243,20 @@ def ensure_coroutine(fn):
         def wrapper(*args, **kwargs):
             raise tornado.gen.Return(fn(*args, **kwargs))
         return wrapper
+
+
+def is_mutable_property(cls, attribute):
+    """
+    Determine whether the given attribute is a mutable property of cls. That is to say that
+    the attribute corresponds to a property whose fset attribute is not None.
+
+    :param cls: the class
+    :param attribute: the attribute
+    :returns: True if the attribute is a mutable property of cls
+    """
+    try:
+        attr = getattr(cls, attribute)
+    except AttributeError:
+        return False
+
+    return isinstance(attr, property) and attr.fset is not None


### PR DESCRIPTION
Fixes #54 

The exposing of ports of a certain ProcessSpec into a PortNamespace allows
for the definition of exclude or include rules. When the user later wants
to retrieve the exposed ports given a set of inputs, this should be mapped
on the actual exposed ports and not on the ports of the relevant ProcessSpec.
To make this possible, the actual ports that are exposed should be stored
in a memory container, indexed by the Process where the ports came from and
the namespace into which they were exposed.

Additionally, the exposing of ports can be done in an arbitrarily nested
PortNamespace. When exposing a PortNamespace of a given ProcessSpec into
oneself, one should not just copy the ports, but also all the mutable
properties of the donor PortNamespace. This is now properly implemented in
the PortNamespace.absorb() method.