### PR TITLE
Implement a `Process.status` attribute that can be set through ProcessActions

### DIFF
--- a/plumpy/process_comms.py
+++ b/plumpy/process_comms.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 
 from . import loaders
@@ -48,8 +49,13 @@ class ProcessAction(communications.Action):
 
 
 class PauseAction(ProcessAction):
-    def __init__(self, pid):
-        super(PauseAction, self).__init__(pid, PAUSE_MSG)
+    def __init__(self, pid, msg=None):
+        if msg is not None:
+            message = copy.copy(PAUSE_MSG)
+            message[MESSAGE_KEY] = msg
+        else:
+            message = PAUSE_MSG
+        super(PauseAction, self).__init__(pid, message)
 
 
 class PlayAction(ProcessAction):
@@ -65,8 +71,11 @@ class StatusAction(ProcessAction):
 class KillAction(ProcessAction):
     def __init__(self, pid, msg=None):
         if msg is not None:
-            KILL_MSG[MESSAGE_KEY] = msg
-        super(KillAction, self).__init__(pid, KILL_MSG)
+            message = copy.copy(KILL_MSG)
+            message[MESSAGE_KEY] = msg
+        else:
+            message = KILL_MSG
+        super(KillAction, self).__init__(pid, message)
 
 
 TASK_KEY = 'task'

--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -32,7 +32,10 @@ __all__ = [
     'Kill',
     'Stop',
     'Wait',
-    'Continue'
+    'Continue',
+    'Interruption',
+    'KillInterruption',
+    'PauseInterruption',
 ]
 
 
@@ -300,6 +303,8 @@ class Waiting(State):
         callback_name = saved_state.get(self.DONE_CALLBACK, None)
         if callback_name is not None:
             self.done_callback = getattr(self.process, callback_name)
+        else:
+            self.done_callback = None
         self._waiting_future = futures.Future()
 
     def interrupt(self, reason):


### PR DESCRIPTION
Fixes #57 

This new functionality is then used by the `PauseAction` process action,
which now takes an optional message that will be set as the status attribute
of the process. Any status that might have already been set is stored, such
that when the process is unpaused, the original status can be restored.