### PR TITLE
Persist the `Process._paused` future in the `save_instance_state`

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -72,7 +72,7 @@ yaml.representer.Representer.add_representer(
     ProcessStateMachineMeta, yaml.representer.Representer.represent_name)
 
 
-@persistence.auto_persist('_pid', '_CREATION_TIME', '_future', '_status', '_pre_paused_status')
+@persistence.auto_persist('_pid', '_CREATION_TIME', '_future', '_paused', '_status', '_pre_paused_status')
 class Process(
     with_metaclass(ProcessStateMachineMeta, StateMachine,
                    persistence.Savable)):
@@ -513,7 +513,7 @@ class Process(
         self._setup_event_hooks()
 
         # Runtime variables, set initial states
-        self._future = futures.Future()
+        self._future = persistence.SavableFuture()
         self.__event_helper = utils.EventHelper(ProcessListener)
         self._logger = None
         self._communicator = None
@@ -702,7 +702,7 @@ class Process(
         self._pausing = None
 
         # Create a future to represent the duration of the paused state
-        self._paused = futures.Future()
+        self._paused = persistence.SavableFuture()
 
         # Save the current status and potentially overwrite it with the passed message
         self._pre_paused_status = self.status

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -531,6 +531,10 @@ class TestProcessSaving(utils.TestCaseWithLoop):
             self.assertListEqual([SavePauseProc.run.__name__, SavePauseProc.step2.__name__], nsync_comeback.steps_ran)
 
             proc_unbundled = bundle.unbundle()
+
+            # At bundle time the Process was paused, the future of which will be persisted to the bundle.
+            # As a result the process, recreated from that bundle, will also be paused and will have to be played
+            proc_unbundled.play()
             self.assertEqual(0, len(proc_unbundled.steps_ran))
             yield proc_unbundled.step_until_terminated()
             self.assertEqual([SavePauseProc.step2.__name__], proc_unbundled.steps_ran)


### PR DESCRIPTION
This is important to maintain the paused status of a Process between
saving and loading its instance state. Before a paused Process, when
reloaded from instance state would automatically continue.