### PR TITLE
Call `step_until_terminated` in ProcessLauncher methods for nowait=True

### DIFF
--- a/plumpy/process_comms.py
+++ b/plumpy/process_comms.py
@@ -280,6 +280,7 @@ class ProcessLauncher(object):
             self._persister.save_checkpoint(proc)
 
         if nowait:
+            self._loop.add_callback(proc.step_until_terminated)
             raise gen.Return(proc.pid)
 
         yield proc.step_until_terminated()
@@ -298,6 +299,7 @@ class ProcessLauncher(object):
         proc = saved_state.unbundle(self._load_context)
 
         if nowait:
+            self._loop.add_callback(proc.step_until_terminated)
             raise gen.Return(proc.pid)
 
         yield proc.step_until_terminated()


### PR DESCRIPTION
Fixes #65 

Without this call the task is acknowledged but the Process is actually
never completed in the `_launch` or `_continue` methods.