### PR TITLE
Ensure communicator for CommunicatorWrapper is not None

### DIFF
--- a/plumpy/communications.py
+++ b/plumpy/communications.py
@@ -68,6 +68,8 @@ class CommunicatorWrapper(kiwipy.Communicator):
         :param loop: The tornado event loop to schedule callbacks on
         :type loop: :class:`tornado.ioloop.IOLoop`
         """
+        assert communicator is not None
+
         self._communicator = communicator
         self._loop = loop or ioloop.IOLoop.current()
         self._subscribers = {}

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -253,7 +253,7 @@ class Process(
         if communicator is None:
             self._communicator = None
         else:
-            self._communicator = communications.CommunicatorWrapper(communicator)
+            self._communicator = communications.CommunicatorWrapper(communicator, self._loop)
 
     @base.super_check
     def init(self):
@@ -524,8 +524,8 @@ class Process(
 
         self._state = self.recreate_state(saved_state['_state'])
 
-        if 'communicator' in load_context:
-            self._communicator = communications.CommunicatorWrapper(load_context.communicator)
+        if 'communicator' in load_context and load_context.communicator is not None:
+            self._communicator = communications.CommunicatorWrapper(load_context.communicator, self._loop)
 
         if 'logger' in load_context:
             self._logger = load_context.logger


### PR DESCRIPTION
Fixes #69 

This is enforced by putting an assert on the value of the communicator
in the constructor in the wrapper. This problem was found because in
the `load_instance_state` a `CommunicatorWrapper` was being instantiated
as long as the key `communicator` was present in the `load_context`
regardless of its value. This led to guards in the `Process` class for
the presence of communicator to be misled, because it would hold a
communicator wrapper, but it could not communicate, since its communicator
was None.