### PR TITLE
Catch TimeoutError of `add_rpc_subscriber` in `Process.init`

### DIFF
--- a/plumpy/exceptions.py
+++ b/plumpy/exceptions.py
@@ -5,10 +5,6 @@ class KilledError(Exception):
     """The process was killed."""
 
 
-class TimeoutError(Exception):
-    pass
-
-
 class Unsupported(Exception):
     pass
 

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -18,6 +18,8 @@ from tornado import concurrent, gen
 import tornado.stack_context
 import yaml
 
+import kiwipy
+
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
 from .utils import protected
@@ -255,7 +257,11 @@ class Process(StateMachine, persistence.Savable):
     def init(self):
         """ Any common initialisation stuff after create or load goes here """
         if self._communicator is not None:
-            self._communicator.add_rpc_subscriber(self.message_receive, identifier=str(self.pid))
+            try:
+                self._communicator.add_rpc_subscriber(self.message_receive, identifier=str(self.pid))
+            except kiwipy.TimeoutError:
+                self.logger.exception("Failed to add RPC subscriber to process<{}> so it won't respond to RPCs".format(
+                    self.pid))
 
         if not self._future.done():
 


### PR DESCRIPTION
The `add_rpc_subscriber` call on the communicator in the `init` call
of a `Process` can timeout with a `TimeoutError`, but this should not
topple the process itself. Instead, it should log the error to notify
the user that the process won't be able to respond to RPC calls. When
it is reloaded, it has another chance to add the RPC subscriber and
continue functioning normally.