### PR TITLE
Catch `TimeoutError` of `remove_rpc_subscriber` in `Process.close`

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -813,7 +813,7 @@ class Process(StateMachine, persistence.Savable):
         if self._communicator is not None:
             try:
                 self._communicator.remove_rpc_subscriber(str(self.pid))
-            except ValueError:
+            except (kiwipy.TimeoutError, ValueError):
                 self.logger.exception("Process<{}> failed to remove itself as an RPC subscriber".format(self.pid))
 
     # region State related methods


### PR DESCRIPTION
In the previous commit, we already added a catch for the `ValueError`,
which would be thrown if there was no subscriber. However, the call can
also timeout which would throw a `TimeoutError` instead.